### PR TITLE
Resolving startup failure for spark-cluster-task

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		</dependencies>
 	</dependencyManagement>
 
-<profiles>
+	<profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spark-cluster-task-app-dependencies/pom.xml
+++ b/spark-cluster-task-app-dependencies/pom.xml
@@ -15,7 +15,7 @@
     </parent>
 
 	<properties>
-		<spark.version>1.6.2</spark.version>
+		<spark.version>1.6.3</spark.version>
 	</properties>
 
     <dependencyManagement>
@@ -57,7 +57,7 @@
 			</dependency>
 		</dependencies>
     </dependencyManagement>
-<profiles>
+    <profiles>
 		<profile>
 			<id>spring</id>
 			<repositories>

--- a/spring-cloud-starter-task-spark-cluster/src/main/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterEnvironmentPostProcessor.java
+++ b/spring-cloud-starter-task-spark-cluster/src/main/java/org/springframework/cloud/task/app/spark/cluster/SparkClusterEnvironmentPostProcessor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.task.app.spark.cluster;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+
+/**
+ * {@link EnvironmentPostProcessor} implementation that will disable the web environment that seems to be
+ * triggered by a Spark code dependency.
+ *
+ * @author Thomas Risberg
+ */
+public class SparkClusterEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment configurableEnvironment, SpringApplication springApplication) {
+		springApplication.setWebEnvironment(false);
+	}
+}

--- a/spring-cloud-starter-task-spark-cluster/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-starter-task-spark-cluster/src/main/resources/META-INF/spring.factories
@@ -1,5 +1,5 @@
 #
-# Copyright 2016-2017 the original author or authors.
+# Copyright 2017 the original author or authors.
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -14,4 +14,4 @@
 #  limitations under the License.
 #
 
-configuration-properties.classes=org.springframework.cloud.task.app.spark.cluster.SparkClusterTaskProperties
+org.springframework.boot.env.EnvironmentPostProcessor=org.springframework.cloud.task.app.spark.cluster.SparkClusterEnvironmentPostProcessor


### PR DESCRIPTION
- adding EnvironmentPostProcessor to turn off web environment which seems to be triggered in newer Boot version by a Spark dependency

- updating to Spark 1.6.3

- removing obsolete referende to white-list property class for common properties

Resolves #1